### PR TITLE
Ensure itemscope always starts a new item

### DIFF
--- a/microdata_test.go
+++ b/microdata_test.go
@@ -583,8 +583,9 @@ func TestSkipSelfReferencingItemref(t *testing.T) {
 	actual := ParseData(html, t)
 
 	child := NewItem()
-	child.AddString("title", "Foo")
+	child.AddType("http://data-vocabulary.org/Breadcrumb")
 	child.AddString("url", "http://example.com/foo/bar")
+	child.AddString("title", "Foo")
 
 	item := NewItem()
 	item.AddType("http://schema.org/WebPage")
@@ -603,18 +604,16 @@ func TestSkipSelfReferencingItemref(t *testing.T) {
 // of its container item.
 func TestPropertiesInContainedItem(t *testing.T) {
 	html := `
-      <body itemscope itemtype="http://schema.org/WebPage">
-        <meta itemprop="foo" content="foo value">
+		<body itemscope itemtype="http://schema.org/WebPage">
+			<meta itemprop="foo" content="foo value">
 
-		<div itemscope itemtype="http://schema.org/Person">
-		  <meta itemprop="bar" content="bar value">
-		</div>
-
-		<div itemscope itemtype="http://schema.org/Person" itemprop="author">
-		  <meta itemprop="baz" content="baz value">
-		</div>
-
-	  </body>`
+			<div itemscope itemtype="http://schema.org/Person">
+				<meta itemprop="bar" content="bar value">
+			</div>
+			<div itemscope itemtype="http://schema.org/Person" itemprop="author">
+				<meta itemprop="baz" content="baz value">
+			</div>
+		</body>`
 
 	actual := ParseData(html, t)
 

--- a/microdata_test.go
+++ b/microdata_test.go
@@ -597,3 +597,71 @@ func TestSkipSelfReferencingItemref(t *testing.T) {
 		t.Errorf("Expecting %v but got %v", expected, actual)
 	}
 }
+
+// This test validates that properties within an itemscope'd element remain
+// with that contained item even if it is not, via itemprop, made an explicit child
+// of its container item.
+func TestPropertiesInContainedItem(t *testing.T) {
+	html := `
+      <body itemscope itemtype="http://schema.org/WebPage">
+        <meta itemprop="foo" content="foo value">
+
+		<div itemscope itemtype="http://schema.org/Person">
+		  <meta itemprop="bar" content="bar value">
+		</div>
+
+		<div itemscope itemtype="http://schema.org/Person" itemprop="author">
+		  <meta itemprop="baz" content="baz value">
+		</div>
+
+	  </body>`
+
+	actual := ParseData(html, t)
+
+	// There should be two top-level items: WebPage and the Person that isn't an author.
+	if len(actual.Items) != 2 {
+		t.Fatalf("expected 2 top-level items, got %d", len(actual.Items))
+	}
+
+	outer := actual.Items[0]
+	inner := actual.Items[1]
+
+	// The first item should be a WebPage.  The properties in its contained items should
+	// not be properties of the containing item.
+	if len(outer.Types) != 1 || outer.Types[0] != "http://schema.org/WebPage" {
+		t.Fatalf("expected outer to be http://schema.org/WebPage, got %v", outer.Types)
+	}
+	if _, present := outer.Properties["bar"]; present {
+		t.Errorf("outer should not have a 'bar' property, got %v", outer.Properties["bar"])
+	}
+	if _, present := outer.Properties["baz"]; present {
+		t.Errorf("outer should not have a 'baz' property, got %v", outer.Properties["baz"])
+	}
+
+	// The second item should be the non-author child element of outer.  Since there is
+	// no itemprop attribute, it's not a child *item* of outer but it should stand as its
+	// own item.
+	if len(inner.Types) != 1 || inner.Types[0] != "http://schema.org/Person" {
+		t.Fatalf("expected inner to be http://schema.org/Person, got %v", inner.Types)
+	}
+	if _, present := inner.Properties["bar"]; !present {
+		t.Errorf("inner should have a 'bar' property")
+	}
+
+	// The third item is the author, which should be a child item (via the 'author' itemprop)
+	// of outer.  It, too, should have its own discrete type and property.
+	if list := outer.Properties["author"]; len(list) == 1 {
+		if author, ok := list[0].(*Item); ok {
+			if len(author.Types) != 1 || author.Types[0] != "http://schema.org/Person" {
+				t.Fatalf("expected author to be http://schema.org/Person, got %v", author.Types)
+			}
+			if _, present := author.Properties["baz"]; !present {
+				t.Errorf("inner should have a 'baz' property")
+			}
+		} else {
+			t.Errorf("expected author item, got %v", list)
+		}
+	} else {
+		t.Errorf("expected outer to have a child of author, got %v", outer.Properties["author"])
+	}
+}


### PR DESCRIPTION
https://www.w3.org/TR/microdata/#items

> An element with the itemscope attribute specified creates a new item, a group of name-value pairs that describe properties, and their values, of the thing represented by that element.

The implementation appears to have buggy behavior when an element has an `itemscope` but no `itemprop`; a top-level item is created, but it is missing its `itemtype`, and any `itemprop`s contained within it are attached to the item associated with the containing element, rather than the nested element with an `itemscope`.  Effectively:

```html
<a itemscope itemtype="a-type">
  <meta itemprop="foo" content="value">
  <b itemscope itemtype="b-type">
    <meta itemprop="bar content="value">
  </b>
</a>
```

Generates data like this:

- `a`
  - type: a-type
  - property foo: value
  - property bar: value
- `b`

This PR ensures both top-level items and nested items are handled consistently, producing an item hierarchy like:

- `a`
  - type: a-type
  - property foo: value
- `b`
  - type: b-type
  - property bar: value

The presence of an `itemprop` on `b` therefore just changes where `b`'s associated item is parented in the hierarchy without changing which item gets properties contained within it.  This PR has two commits; the first has tests that can be run to verify the problem, and the second fixes the problem.